### PR TITLE
Remove dtype argument to juf.convert

### DIFF
--- a/sf_daq_broker/writer/convert_file.py
+++ b/sf_daq_broker/writer/convert_file.py
@@ -117,7 +117,6 @@ def convert_file(file_in, file_out, json_run_file, detector_config_file):
                     downsample=downsample,
                     compression=compression,
                     factor=factor,
-                    dtype=None,
                     batch_size=35,
                 )
             else:


### PR DESCRIPTION
This is deprecated and will be removed in the future major version of jungfrau_utils.