### PR TITLE
adding module_edge_pixels parameter

### DIFF
--- a/broker_rest_api.md
+++ b/broker_rest_api.md
@@ -163,6 +163,8 @@ When providing detector-specific parameters within the "detectors" key:
 
     * `"double_pixels_action"` (str): Handling of double pixels at chip inner edges.
 
+    * `"module_edge_pixels"` (str): Handling of pixels on the module edges.
+
     * `"geometry"` (bool): Apply geometry correction.
 
     * `"gap_pixels"` (bool): Add gap pixels between detector chips.

--- a/sf_daq_broker/writer/convert_file.py
+++ b/sf_daq_broker/writer/convert_file.py
@@ -43,12 +43,14 @@ def convert_file(file_in, file_out, json_run_file, detector_config_file):
         gap_pixels           = detector_params.get("gap_pixels", True)
         geometry             = detector_params.get("geometry", False)
         mask                 = detector_params.get("mask", True)
+        module_edge_pixels   = detector_params.get("module_edge_pixels", "keep")
     else:
         double_pixels_action = "keep"
         factor               = None
         gap_pixels           = False
         geometry             = False
         mask                 = False
+        module_edge_pixels   = "keep"
 
     roi = detector_params.get("roi", None)
     save_ppicker_events_only = detector_params.get("save_ppicker_events_only", False)
@@ -68,6 +70,7 @@ def convert_file(file_in, file_out, json_run_file, detector_config_file):
             conversion=conversion,
             mask=mask,
             double_pixels=double_pixels_action,
+            module_edge_pixels=module_edge_pixels,
             gap_pixels=gap_pixels,
             geometry=geometry,
             parallel=True,


### PR DESCRIPTION
Adding module_edge_pixels parameter to pass it to jungfrau_utils.

links to:
[jungfrau_utils commit adding it](https://github.com/paulscherrerinstitute/jungfrau_utils/commit/4b5d82c235888f4be2634aee38865aef4a020597)
[enabling it for dap](https://gitea.psi.ch/sf-daq/dap/pulls/10)
[enabling it for slic](https://gitea.psi.ch/slic/slic/pulls/33)